### PR TITLE
feat: Review 도메인 클래스 수정

### DIFF
--- a/src/main/java/com/ray/pomin/review/domain/OwnerReview.java
+++ b/src/main/java/com/ray/pomin/review/domain/OwnerReview.java
@@ -10,7 +10,7 @@ import jakarta.persistence.ManyToOne;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
-public class AdminReview extends BaseEntity {
+public class OwnerReview extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/com/ray/pomin/review/domain/Review.java
+++ b/src/main/java/com/ray/pomin/review/domain/Review.java
@@ -4,6 +4,7 @@ import com.ray.pomin.global.domain.BaseEntity;
 import com.ray.pomin.order.domain.Order;
 import com.ray.pomin.store.domain.Store;
 import com.ray.pomin.user.domain.Customer;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -12,6 +13,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 
@@ -38,8 +44,11 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "STORE_ID")
     private Store store;
 
-    @ManyToOne(fetch = LAZY)
+    @OneToOne(fetch = LAZY)
     @JoinColumn(name = "ORDER_ID")
     private Order order;
+
+    @OneToMany(fetch = LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewImage> images = new ArrayList<>();
 
 }

--- a/src/main/java/com/ray/pomin/review/domain/Review.java
+++ b/src/main/java/com/ray/pomin/review/domain/Review.java
@@ -5,7 +5,6 @@ import com.ray.pomin.order.domain.Order;
 import com.ray.pomin.store.domain.Store;
 import com.ray.pomin.user.domain.Customer;
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;

--- a/src/main/java/com/ray/pomin/review/domain/Review.java
+++ b/src/main/java/com/ray/pomin/review/domain/Review.java
@@ -7,6 +7,7 @@ import com.ray.pomin.user.domain.Customer;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -32,7 +33,7 @@ public class Review extends BaseEntity {
     @Embedded
     private Star star;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private VisibleType visibleType;
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/com/ray/pomin/review/domain/Review.java
+++ b/src/main/java/com/ray/pomin/review/domain/Review.java
@@ -4,7 +4,10 @@ import com.ray.pomin.global.domain.BaseEntity;
 import com.ray.pomin.order.domain.Order;
 import com.ray.pomin.store.domain.Store;
 import com.ray.pomin.user.domain.Customer;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -21,8 +24,10 @@ public class Review extends BaseEntity {
 
     private String content;
 
-    private int star;
+    @Embedded
+    private Star star;
 
+    @Enumerated
     private VisibleType visibleType;
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/com/ray/pomin/review/domain/Star.java
+++ b/src/main/java/com/ray/pomin/review/domain/Star.java
@@ -1,0 +1,20 @@
+package com.ray.pomin.review.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class Star {
+
+  private int star;
+
+}
+

--- a/src/main/java/com/ray/pomin/review/domain/Star.java
+++ b/src/main/java/com/ray/pomin/review/domain/Star.java
@@ -1,6 +1,5 @@
 package com.ray.pomin.review.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,4 +16,3 @@ public class Star {
   private int star;
 
 }
-

--- a/src/main/java/com/ray/pomin/review/domain/VisibleType.java
+++ b/src/main/java/com/ray/pomin/review/domain/VisibleType.java
@@ -1,4 +1,5 @@
 package com.ray.pomin.review.domain;
 
 public enum VisibleType {
+  ALL, OWNER_ONLY, ADMIN_ONLY;
 }


### PR DESCRIPTION
## 📌 PR 설명
- 리뷰의 VisibleType : 모두(ALL) / 사장님만(OWNER_ONLY) / 관리자만(ADMIN_ONLY)
- 고객은 주문 당 한 건의 리뷰를 작성할 수 있음 : @ ManyToOne -> @ OneToOne 변경
- ReviewImage는 Review 에 종속됨 : 양방향매핑 추가 및 cascadeType, orphanRemoval 속성 설정

## ❓ 의견이 필요한 부분
- 리뷰의 VisibleType이 OWNER_ONLY 여도 사실상 사장님 + 관리자가 볼 수 있다. Enum 값 이름을 좀더 명확히 변경해야할지
- Review 에 종속적이고, 사실상 수정 개념 없이 추가/삭제만 되는 ReviewImage가 또 별도로 BaseEntity를 상속받아야 하는지 (현재 상속중)