### PR TITLE
[POM-38] feat: OAuth 로그인 기능 진행

### DIFF
--- a/src/main/java/com/ray/pomin/customer/domain/Customer.java
+++ b/src/main/java/com/ray/pomin/customer/domain/Customer.java
@@ -4,11 +4,16 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.ray.pomin.global.util.Validator.Condition.hasContent;
 import static com.ray.pomin.global.util.Validator.validate;
+import static jakarta.persistence.CascadeType.ALL;
 import static java.util.Objects.isNull;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -29,18 +34,29 @@ public class Customer {
     @Embedded
     private CustomerInfo information;
 
-    public Customer(Login login, String nickname, CustomerInfo information) {
+    @OneToMany(mappedBy = "customer", cascade = ALL, orphanRemoval = true)
+    private List<LoginProvider> loginProviders = new ArrayList<>();
+
+    public Customer(Login login, String nickname, CustomerInfo information, Provider provider) {
         validate(!isNull(login), "로그인 정보는 필수 값입니다");
         validate(hasContent(nickname), "닉네임은 필수 값입니다");
         validate(!isNull(information), "사용자 정보는 필수 값입니다");
+        validate(!isNull(provider), "로그인 제공자 정보는 필수 값입니다");
 
         this.login = login;
         this.nickname = nickname;
         this.information = information;
+        this.loginProviders.add(new LoginProvider(provider, this));
     }
 
     public String getEmail() {
         return login.getEmail();
     }
 
+    public Customer addLoginProvider(String providerName) {
+        Customer customer = new Customer(this.login, this.nickname, this.information, Provider.valueOf(providerName));
+        customer.loginProviders.addAll(this.loginProviders);
+
+        return customer;
+    }
 }

--- a/src/main/java/com/ray/pomin/customer/domain/Customer.java
+++ b/src/main/java/com/ray/pomin/customer/domain/Customer.java
@@ -38,15 +38,19 @@ public class Customer {
     private List<LoginProvider> loginProviders = new ArrayList<>();
 
     public Customer(Login login, String nickname, CustomerInfo information, Provider provider) {
-        validate(!isNull(login), "로그인 정보는 필수 값입니다");
-        validate(hasContent(nickname), "닉네임은 필수 값입니다");
-        validate(!isNull(information), "사용자 정보는 필수 값입니다");
-        validate(!isNull(provider), "로그인 제공자 정보는 필수 값입니다");
+        validateCustomer(login, nickname, information, provider);
 
         this.login = login;
         this.nickname = nickname;
         this.information = information;
         this.loginProviders.add(new LoginProvider(provider, this));
+    }
+
+    private static void validateCustomer(Login login, String nickname, CustomerInfo information, Provider provider) {
+        validate(!isNull(login), "로그인 정보는 필수 값입니다");
+        validate(hasContent(nickname), "닉네임은 필수 값입니다");
+        validate(!isNull(information), "사용자 정보는 필수 값입니다");
+        validate(!isNull(provider), "로그인 제공자 정보는 필수 값입니다");
     }
 
     public String getEmail() {

--- a/src/main/java/com/ray/pomin/customer/domain/Login.java
+++ b/src/main/java/com/ray/pomin/customer/domain/Login.java
@@ -8,7 +8,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static com.ray.pomin.global.util.Validator.Condition.regex;
 import static com.ray.pomin.global.util.Validator.validate;
-import static java.util.Objects.isNull;
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
@@ -25,16 +24,12 @@ public class Login {
 
     private String password;
 
-    private Provider provider;
-
-    public Login(String email, String password, Provider provider, PasswordEncoder passwordEncoder) {
+    public Login(String email, String password, PasswordEncoder passwordEncoder) {
         validate(regex(EMAIL_PATTERN, email), "이메일 패턴이 일치하지 않습니다");
         validate(regex(PASSWORD_PATTERN, password), "비밀번호 패턴이 일치하지 않습니다");
-        validate(!isNull(provider), "로그인 제공자 정보는 필수 값입니다");
 
         this.email = email;
         this.password = passwordEncoder.encode(password);
-        this.provider = provider;
     }
 
 }

--- a/src/main/java/com/ray/pomin/customer/domain/LoginProvider.java
+++ b/src/main/java/com/ray/pomin/customer/domain/LoginProvider.java
@@ -1,12 +1,14 @@
 package com.ray.pomin.customer.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.NoArgsConstructor;
 
+import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -18,10 +20,11 @@ public class LoginProvider {
     @GeneratedValue
     private Long id;
 
+    @Enumerated(STRING)
     private Provider provider;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "customer_id")
+    @JoinColumn(name = "CUSTOMER_ID")
     private Customer customer;
 
     public LoginProvider(Provider provider, Customer customer) {

--- a/src/main/java/com/ray/pomin/customer/domain/LoginProvider.java
+++ b/src/main/java/com/ray/pomin/customer/domain/LoginProvider.java
@@ -1,0 +1,32 @@
+package com.ray.pomin.customer.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class LoginProvider {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private Provider provider;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+
+    public LoginProvider(Provider provider, Customer customer) {
+        this.provider = provider;
+        this.customer = customer;
+    }
+
+}

--- a/src/main/java/com/ray/pomin/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/ray/pomin/customer/repository/CustomerRepository.java
@@ -1,0 +1,12 @@
+package com.ray.pomin.customer.repository;
+
+import com.ray.pomin.customer.domain.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+
+    Optional<Customer> findByLoginEmail(String email);
+
+}

--- a/src/main/java/com/ray/pomin/global/auth/OAuthSuccessHandler.java
+++ b/src/main/java/com/ray/pomin/global/auth/OAuthSuccessHandler.java
@@ -1,6 +1,8 @@
 package com.ray.pomin.global.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ray.pomin.customer.domain.Customer;
+import com.ray.pomin.customer.repository.CustomerRepository;
 import com.ray.pomin.global.auth.model.OAuthCustomer;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,12 +14,14 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
 public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final ObjectMapper objectMapper;
+    private final CustomerRepository customerRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -25,9 +29,24 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
         response.setCharacterEncoding("UTF-8");
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        Optional<Customer> findCustomer = customerRepository.findByLoginEmail(oAuthCustomer.getRegistration().email());
+        if (findCustomer.isPresent()) {
+            Customer customer = findCustomer.get().addLoginProvider(oAuthCustomer.getRegistration().providerName());
+            customerRepository.save(customer);
+
+            response.getWriter().println(objectMapper.writeValueAsString(createJWT(customer)));
+
+            return;
+        }
+
         response.setHeader("Location", "/api/v1/customers");
 
         response.getWriter().println(objectMapper.writeValueAsString(oAuthCustomer.getRegistration()));
+    }
+
+    private String createJWT(Customer customer) {
+        return "accessToken";
     }
 
 }

--- a/src/main/java/com/ray/pomin/global/auth/dto/CustomerRegistration.java
+++ b/src/main/java/com/ray/pomin/global/auth/dto/CustomerRegistration.java
@@ -1,3 +1,3 @@
 package com.ray.pomin.global.auth.dto;
 
-public record CustomerRegistration(String email, String name, String password){}
+public record CustomerRegistration(String email, String name, String providerName){}


### PR DESCRIPTION
## 📌 설명
이미 가입된 email을 가진 OAuth로 가입을 진행 시 해당 계정으로 연결

## 👩‍💻 요구 사항과 구현 내용
- [x] OAuth 인증 서버로부터 사용자 정보 가져오기
- [x] Provider와 Customer 다대일 관계로 분리하여 하나의 고객이 여러 방식으로 같은 계정으로 회원가입 및 로그인 진행
- [ ] 추가 필요 값 받아서 저장
- [ ]  로그인 후 JWT 발급

## ✅ PR 포인트 & 궁금한 점
조건이 있는데 OAuth Resource server로 부터 받은 email을 기준으로
- 이미 가입된 email이 있는 경우
    - 해당 계정과 연동을 하여 하나의 계정처럼 사용할 수 있도록 구현
- 가입된 email이 없는 경우
    - 단순 가입 
이렇게 보면 될 것 같습니다

`OAuthSuccessHandler`에서 이미 가입된 email이 있는 경우를 조회하여 연결하는 것으로 수정했습니다