### PR TITLE
[POM-69] feat: 결제 취소 로직 구현

### DIFF
--- a/src/main/java/com/ray/pomin/payment/controller/PaymentController.java
+++ b/src/main/java/com/ray/pomin/payment/controller/PaymentController.java
@@ -8,7 +8,6 @@ import com.ray.pomin.payment.domain.Payment;
 import com.ray.pomin.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -49,7 +48,6 @@ public class PaymentController {
   public ResponseEntity<PaymentFailResponse> fail(@RequestParam String code,
                                                   @RequestParam String message,
                                                   @RequestParam String orderId) {
-
     return new ResponseEntity<>(new PaymentFailResponse(message, orderId), HttpStatus.valueOf(code));
   }
 

--- a/src/main/java/com/ray/pomin/payment/controller/PaymentController.java
+++ b/src/main/java/com/ray/pomin/payment/controller/PaymentController.java
@@ -1,7 +1,6 @@
 package com.ray.pomin.payment.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.ray.pomin.payment.controller.dto.PaymentCancelResponse;
 import com.ray.pomin.payment.controller.dto.PaymentFailResponse;
 import com.ray.pomin.payment.controller.dto.PaymentResponse;
 import com.ray.pomin.payment.domain.Payment;
@@ -52,12 +51,11 @@ public class PaymentController {
   }
 
   @PatchMapping("/payments/{paymentId}")
-  public ResponseEntity<PaymentCancelResponse> cancel(@PathVariable Long paymentId) {
+  public ResponseEntity<Void> cancel(@PathVariable Long paymentId) {
     Payment paymentToCancel = paymentService.findOne(paymentId);
-    PaymentCancelResponse cancelResponse = paymentService.cancel(paymentToCancel);
+    paymentService.cancel(paymentToCancel);
 
-    return ResponseEntity.status(HttpStatus.valueOf(cancelResponse.code()))
-            .body(cancelResponse);
+    return ResponseEntity.noContent().build();
   }
 
   @GetMapping("/payments/{paymentId}")

--- a/src/main/java/com/ray/pomin/payment/controller/dto/PaymentCancelRequest.java
+++ b/src/main/java/com/ray/pomin/payment/controller/dto/PaymentCancelRequest.java
@@ -1,0 +1,5 @@
+package com.ray.pomin.payment.controller.dto;
+
+public record PaymentCancelRequest(String cancelReason) {
+
+}

--- a/src/main/java/com/ray/pomin/payment/controller/dto/PaymentCancelResponse.java
+++ b/src/main/java/com/ray/pomin/payment/controller/dto/PaymentCancelResponse.java
@@ -1,0 +1,5 @@
+package com.ray.pomin.payment.controller.dto;
+
+public record PaymentCancelResponse(int code, String message) {
+
+}

--- a/src/main/java/com/ray/pomin/payment/domain/PGInfo.java
+++ b/src/main/java/com/ray/pomin/payment/domain/PGInfo.java
@@ -18,7 +18,7 @@ import static lombok.AccessLevel.*;
 public class PGInfo {
 
   @Enumerated(STRING)
-  @Column(name = "PGType")
+  @Column(name = "PG_TYPE")
   private PGType provider;
 
   private String payKey;
@@ -29,6 +29,14 @@ public class PGInfo {
 
     this.provider = provider;
     this.payKey = payKey;
+  }
+
+  public PGType getProvider() {
+    return provider;
+  }
+
+  public String getPayKey() {
+    return payKey;
   }
 
 }

--- a/src/main/java/com/ray/pomin/payment/domain/Payment.java
+++ b/src/main/java/com/ray/pomin/payment/domain/Payment.java
@@ -70,7 +70,7 @@ public class Payment extends BaseTimeEntity {
   }
 
   public Payment cancel() {
-    status = CANCELLED;
+    status = CANCELED;
     return this;
   }
 

--- a/src/main/java/com/ray/pomin/payment/domain/Payment.java
+++ b/src/main/java/com/ray/pomin/payment/domain/Payment.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
@@ -37,6 +38,7 @@ public class Payment extends BaseTimeEntity {
   @Embedded
   private PayInfo payInfo;
 
+  @Builder
   public Payment(int amount, PaymentStatus status, PGInfo pgInfo, PayInfo payInfo) {
     validate(amount > 0, "결제금액은 0 보다 커야합니다");
     validate(!isNull(status), "결제상태는 필수 값입니다");
@@ -70,8 +72,12 @@ public class Payment extends BaseTimeEntity {
   }
 
   public Payment cancel() {
-    status = CANCELED;
-    return this;
+    return Payment.builder()
+                    .amount(amount)
+                    .status(CANCELED)
+                    .pgInfo(new PGInfo(pgInfo.getProvider(), pgInfo.getPayKey()))
+                    .payInfo(new PayInfo(payInfo.getMethod(), payInfo.getType()))
+                    .build();
   }
 
 }

--- a/src/main/java/com/ray/pomin/payment/domain/Payment.java
+++ b/src/main/java/com/ray/pomin/payment/domain/Payment.java
@@ -11,6 +11,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import static com.ray.pomin.global.util.Validator.validate;
+import static com.ray.pomin.payment.domain.PaymentStatus.*;
 import static jakarta.persistence.EnumType.STRING;
 import static java.util.Objects.isNull;
 import static lombok.AccessLevel.PROTECTED;
@@ -62,6 +63,15 @@ public class Payment extends BaseTimeEntity {
 
   public PayInfo getPayInfo() {
     return payInfo;
+  }
+
+  public PGInfo getPgInfo() {
+    return pgInfo;
+  }
+
+  public Payment cancel() {
+    status = CANCELLED;
+    return this;
   }
 
 }

--- a/src/main/java/com/ray/pomin/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/ray/pomin/payment/domain/PaymentStatus.java
@@ -2,5 +2,5 @@ package com.ray.pomin.payment.domain;
 
 public enum PaymentStatus {
   COMPLETE,
-  CANCELLED;
+  CANCELED
 }

--- a/src/main/java/com/ray/pomin/payment/service/PaymentService.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentService.java
@@ -1,5 +1,10 @@
 package com.ray.pomin.payment.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ray.pomin.payment.controller.dto.PaymentCancelRequest;
+import com.ray.pomin.payment.controller.dto.PaymentCancelResponse;
 import com.ray.pomin.payment.domain.PGInfo;
 import com.ray.pomin.payment.domain.PGType;
 import com.ray.pomin.payment.domain.PayInfo;
@@ -12,19 +17,23 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.text.MessageFormat;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static com.ray.pomin.payment.domain.PayMethod.EASYPAY;
 import static com.ray.pomin.payment.domain.PayMethod.findByTitle;
 import static com.ray.pomin.payment.domain.PaymentStatus.COMPLETE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Base64.getEncoder;
+import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.OK;
 
 @Slf4j
@@ -35,13 +44,13 @@ public class PaymentService {
   @Value("${toss.api.testSecretApiKey}")
   private String secretKey;
 
-  private final String FINAL_TOSSPAYMENT_URL = "https://api.tosspayments.com/v1/payments/confirm";
+  private final ObjectMapper objectMapper;
 
   private final PaymentRepository paymentRepository;
 
   @Transactional
-  public Long doFinalPaymentRequest(String orderId, String paymentKey, int amount) {
-    ResponseEntity<Map> responseEntity = sendFinalPaymentRequest(orderId, paymentKey, amount);
+  public Long doFinalPaymentRequest(String orderId, String paymentKey, int amount) throws JsonProcessingException {
+    ResponseEntity<String> responseEntity = sendFinalPaymentRequest(orderId, paymentKey, amount);
 
     if (responseEntity.getStatusCode() != OK) {
       throw new IllegalArgumentException("결제에 실패했습니다.");
@@ -50,46 +59,17 @@ public class PaymentService {
     return paymentRepository.save(createPayment(responseEntity.getBody())).getId();
   }
 
-  private Payment createPayment(Map paidRequestBody) {
-    int amount = Integer.parseInt(paidRequestBody.get("totalAmount").toString());
-    String paymentKey = paidRequestBody.get("paymentKey").toString();
-    PayMethod payMethod = findByTitle(paidRequestBody.get("method").toString());
-    PayType payType = getPayType(paidRequestBody, payMethod);
-
-    return new Payment(amount, COMPLETE, new PGInfo(PGType.TOSS, paymentKey),
-            new PayInfo(payMethod, payType));
-  }
-
-  private PayType getPayType(Map paidRequestBody, PayMethod payMethod) {
-    if (payMethod == EASYPAY) {
-      Map<String, Object> easyPay = (Map<String, Object>) paidRequestBody.get("easyPay");
-
-      return PayType.findByTitle(easyPay.get("provider").toString());
-    }
-      Map<String, Object> card = (Map<String, Object>) paidRequestBody.get("card");
-
-      return PayType.findByCode(card.get("issuerCode").toString());
-  }
-
-  private ResponseEntity<Map> sendFinalPaymentRequest(String orderId, String paymentKey, int amount) {
-    HashMap<String, String> paymentRequestInfo = createPaymentReqeust(orderId, paymentKey, amount);
-
+  private ResponseEntity<String> sendFinalPaymentRequest(String orderId, String paymentKey, int amount) {
     RestTemplate restTemplate = new RestTemplate();
-    HttpHeaders headers = createPaymentRequestHeader();
+    HashMap<String, String> paymentRequestInfo = createPaymentRequest(orderId, paymentKey, amount);
+    HttpHeaders headers = createRequestHeader();
     HttpEntity<Object> requestBody = new HttpEntity<>(paymentRequestInfo, headers);
 
-    return restTemplate.postForEntity(FINAL_TOSSPAYMENT_URL, requestBody, Map.class);
+    final String url = "https://api.tosspayments.com/v1/payments/confirm";
+    return restTemplate.postForEntity(url, requestBody, String.class);
   }
 
-  private HttpHeaders createPaymentRequestHeader() {
-    HttpHeaders headers = new HttpHeaders();
-    headers.set("Authorization", getAuthorizations());
-    headers.set("Content-Type", "application/json");
-
-    return headers;
-  }
-
-  private static HashMap<String, String> createPaymentReqeust(String orderId, String paymentKey, int amount) {
+  private HashMap<String, String> createPaymentRequest(String orderId, String paymentKey, int amount) {
     HashMap<String, String> paymentRequestInfo = new HashMap<>();
     paymentRequestInfo.put("paymentKey", paymentKey);
     paymentRequestInfo.put("orderId", orderId);
@@ -98,18 +78,62 @@ public class PaymentService {
     return paymentRequestInfo;
   }
 
+  private Payment createPayment(String paidRequestBody) throws JsonProcessingException {
+    JsonNode jsonNode = objectMapper.readTree(paidRequestBody);
+    PayMethod payMethod = findByTitle(jsonNode.get("method").textValue());
+    String paymentKey = jsonNode.get("paymentKey").textValue();
+    int amount = jsonNode.get("totalAmount").intValue();
+    PayType payType;
+
+    if (payMethod == EASYPAY) {
+       payType = PayType.findByTitle(jsonNode.get("easyPay").get("provider").textValue());
+    } else {
+       payType = PayType.findByCode(jsonNode.get("card").get("issuerCode").textValue());
+    }
+
+    return new Payment(amount, COMPLETE, new PGInfo(PGType.TOSS, paymentKey),
+            new PayInfo(payMethod, payType));
+  }
+
+  private HttpHeaders createRequestHeader() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", getAuthorizations());
+    headers.set("Content-Type", "application/json");
+
+    return headers;
+  }
+
   private String getAuthorizations() {
     byte[] encodedSecretKey = getEncoder().encode((secretKey + ":").getBytes(UTF_8));
 
     return "Basic "+ new String(encodedSecretKey, 0, encodedSecretKey.length);
   }
 
-  public void cancel(Long paymentId) {
+  @Transactional
+  public PaymentCancelResponse cancel(Payment payment) {
+    try {
+      sendPaymentCancelRequest(payment);
+      Payment canceledPayment = payment.cancel();
+      paymentRepository.save(canceledPayment);
 
+      return new PaymentCancelResponse(HttpStatus.NO_CONTENT.value(), "SUCCESS_CANCEL_PAYMENT");
+    } catch (HttpClientErrorException exception) {
+
+        return new PaymentCancelResponse(exception.getStatusCode().value(), exception.getMessage());
+    }
+  }
+
+  private void sendPaymentCancelRequest(Payment payment) {
+    RestTemplate restTemplate = new RestTemplate();
+    String url = MessageFormat.format("https://api.tosspayments.com/v1/payments/{0}/cancel", payment.getPgInfo().getPayKey());
+    HttpEntity<PaymentCancelRequest> requestBody = new HttpEntity<>(new PaymentCancelRequest("결제취소사유"), createRequestHeader());
+
+    restTemplate.exchange(url, POST, requestBody, String.class);
   }
 
   public Payment findOne(Long paymentId) {
-    return null;
+    return paymentRepository.findById(paymentId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 결제건 입니다."));
   }
 
 }

--- a/src/main/resources/templates/pay-test-page.html
+++ b/src/main/resources/templates/pay-test-page.html
@@ -43,8 +43,8 @@
         paymentWidget.requestPayment({ // 인증
             orderId: generateRandomString(), // 요청을 통해 가져온 orderId
             orderName: "주문한_상품들_이름",
-            successUrl: window.location.origin + "/tosspayments/success",
-            failUrl: window.location.origin + "/tosspayments/fail",
+            successUrl: window.location.origin + "/payment/success",
+            failUrl: window.location.origin + "/payment/fail",
         });
     });
 


### PR DESCRIPTION
## 📌 PR 설명
- 외부 api 연동이 필요해서 결제 데이터 생성 ~ 취소 요청 ~ DB 반영 테스트를 프론트에서 직접 값을 넘겨서 수행했습니다.
(테스트 코드는 추후에 추가하겠습니다)
- 결제 요청시 받은 orderId 를 통해 '결제요청 가능한 주문'인지 판단하는 로직은 주문로직 확인 후 추가 예정입니다.