### PR TITLE
[POM-69] feat: PaymentService 역할 분리

### DIFF
--- a/src/main/java/com/ray/pomin/common/util/RestTemplateConfig.java
+++ b/src/main/java/com/ray/pomin/common/util/RestTemplateConfig.java
@@ -1,0 +1,16 @@
+package com.ray.pomin.common.util;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+
+}

--- a/src/main/java/com/ray/pomin/payment/controller/PaymentController.java
+++ b/src/main/java/com/ray/pomin/payment/controller/PaymentController.java
@@ -37,7 +37,7 @@ public class PaymentController {
   public ResponseEntity<Void> create(@RequestParam String orderId,
                                             @RequestParam String paymentKey,
                                             @RequestParam int amount) throws JsonProcessingException {
-    Long paymentId = paymentService.doFinalPaymentRequest(orderId, paymentKey, amount);
+    Long paymentId = paymentService.create(orderId, paymentKey, amount);
 
     return ResponseEntity.created(URI.create("/api/v1/payments" + paymentId)).build();
   }
@@ -51,7 +51,7 @@ public class PaymentController {
   }
 
   @PatchMapping("/payments/{paymentId}")
-  public ResponseEntity<Void> cancel(@PathVariable Long paymentId) {
+  public ResponseEntity<Void> cancel(@PathVariable Long paymentId) throws JsonProcessingException {
     Payment paymentToCancel = paymentService.findOne(paymentId);
     paymentService.cancel(paymentToCancel);
 

--- a/src/main/java/com/ray/pomin/payment/controller/dto/PaymentInfo.java
+++ b/src/main/java/com/ray/pomin/payment/controller/dto/PaymentInfo.java
@@ -1,0 +1,27 @@
+package com.ray.pomin.payment.controller.dto;
+
+import com.ray.pomin.payment.domain.PGInfo;
+import com.ray.pomin.payment.domain.PayInfo;
+import com.ray.pomin.payment.domain.PayMethod;
+import com.ray.pomin.payment.domain.PayType;
+import com.ray.pomin.payment.domain.Payment;
+import com.ray.pomin.payment.domain.PaymentStatus;
+
+import java.time.LocalDateTime;
+
+import static com.ray.pomin.payment.domain.PGType.TOSS;
+import static com.ray.pomin.payment.domain.PaymentStatus.COMPLETE;
+
+public record PaymentInfo( int amount, PaymentStatus status, String paymentKey, PayMethod payMethod, PayType payType, LocalDateTime approvedAt) {
+
+    public Payment toEntity() {
+        return Payment.builder()
+                .amount(amount)
+                .status(COMPLETE)
+                .pgInfo(new PGInfo(TOSS, paymentKey))
+                .payInfo(new PayInfo(payMethod, payType))
+                .approvedAt(approvedAt)
+                .build();
+    }
+
+}

--- a/src/main/java/com/ray/pomin/payment/domain/Payment.java
+++ b/src/main/java/com/ray/pomin/payment/domain/Payment.java
@@ -60,14 +60,14 @@ public class Payment {
     this.approvedAt = approvedAt;
   }
 
-  public Payment cancel(PaymentInfo Paymentinfo) {
+  public Payment cancel(PaymentInfo paymentInfo) {
     return Payment.builder()
                     .id(id)
                     .amount(amount)
-                    .status(Paymentinfo.status())
+                    .status(paymentInfo.status())
                     .pgInfo(new PGInfo(pgInfo.getProvider(), pgInfo.getPayKey()))
                     .payInfo(new PayInfo(payInfo.getMethod(), payInfo.getType()))
-                    .approvedAt(Paymentinfo.approvedAt())
+                    .approvedAt(paymentInfo.approvedAt())
                     .build();
   }
 

--- a/src/main/java/com/ray/pomin/payment/domain/Payment.java
+++ b/src/main/java/com/ray/pomin/payment/domain/Payment.java
@@ -1,6 +1,5 @@
 package com.ray.pomin.payment.domain;
 
-import com.ray.pomin.payment.controller.dto.PaymentInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -16,6 +15,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 import static com.ray.pomin.global.util.Validator.validate;
+import static com.ray.pomin.payment.domain.PaymentStatus.CANCELED;
 import static jakarta.persistence.EnumType.STRING;
 import static java.util.Objects.isNull;
 import static lombok.AccessLevel.PROTECTED;
@@ -60,14 +60,14 @@ public class Payment {
     this.approvedAt = approvedAt;
   }
 
-  public Payment cancel(PaymentInfo paymentInfo) {
+  public Payment cancel(LocalDateTime canceledAt) {
     return Payment.builder()
                     .id(id)
                     .amount(amount)
-                    .status(paymentInfo.status())
+                    .status(CANCELED)
                     .pgInfo(new PGInfo(pgInfo.getProvider(), pgInfo.getPayKey()))
                     .payInfo(new PayInfo(payInfo.getMethod(), payInfo.getType()))
-                    .approvedAt(paymentInfo.approvedAt())
+                    .approvedAt(canceledAt)
                     .build();
   }
 

--- a/src/main/java/com/ray/pomin/payment/service/PaymentGatewayHandler.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentGatewayHandler.java
@@ -1,0 +1,74 @@
+package com.ray.pomin.payment.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.ray.pomin.payment.controller.dto.PaymentCancelRequest;
+import com.ray.pomin.payment.controller.dto.PaymentInfo;
+import com.ray.pomin.payment.domain.Payment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.text.MessageFormat.format;
+import static java.util.Base64.getEncoder;
+import static org.springframework.http.HttpMethod.POST;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentGatewayHandler {
+
+    @Value("${toss.api.testSecretApiKey}")
+    private String secretKey;
+
+    private final RestTemplate restTemplate;
+
+    private final PaymentGatewayResponseParser parser;
+
+    PaymentInfo makePaymentRequest(String orderId, String paymentKey, int amount) throws JsonProcessingException {
+        Map<String, String> paymentRequestBody = createPaymentRequest(orderId, paymentKey, amount);
+        HttpHeaders headers = createRequestHeader();
+        HttpEntity<Object> requestBody = new HttpEntity<>(paymentRequestBody, headers);
+
+        String url = "https://api.tosspayments.com/v1/payments/confirm";
+        ResponseEntity<String> response = restTemplate.exchange(url, POST, requestBody, String.class);
+
+        return parser.getPaymentInfoFrom(response);
+    }
+
+    private Map<String, String> createPaymentRequest(String orderId, String paymentKey, int amount) {
+        return Map.of("paymentKey", paymentKey,
+                "orderId", orderId,
+                "amount", String.valueOf(amount));
+    }
+
+    private HttpHeaders createRequestHeader() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", getAuthorizations());
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return headers;
+    }
+
+    private String getAuthorizations() {
+        byte[] encodedSecretKey = getEncoder().encode((secretKey + ":").getBytes(UTF_8));
+
+        return "Basic "+ new String(encodedSecretKey, 0, encodedSecretKey.length);
+    }
+
+    public PaymentInfo cancelPaymentRequest(Payment payment) throws JsonProcessingException {
+        String url = format("https://api.tosspayments.com/v1/payments/{0}/cancel", payment.getPgInfo().getPayKey());
+        HttpEntity<PaymentCancelRequest> requestBody = new HttpEntity<>(new PaymentCancelRequest("결제취소사유"), createRequestHeader());
+
+        ResponseEntity<String> response = restTemplate.exchange(url, POST, requestBody, String.class);
+
+        return parser.getPaymentInfoFrom(response);
+    }
+
+}

--- a/src/main/java/com/ray/pomin/payment/service/PaymentGatewayHandler.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentGatewayHandler.java
@@ -1,6 +1,5 @@
 package com.ray.pomin.payment.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ray.pomin.payment.controller.dto.PaymentCancelRequest;
 import com.ray.pomin.payment.controller.dto.PaymentInfo;
 import com.ray.pomin.payment.domain.Payment;
@@ -31,7 +30,7 @@ public class PaymentGatewayHandler {
 
     private final PaymentGatewayResponseParser parser;
 
-    PaymentInfo makePaymentRequest(String orderId, String paymentKey, int amount) throws JsonProcessingException {
+    PaymentInfo makePaymentRequest(String orderId, String paymentKey, int amount) {
         Map<String, String> paymentRequestBody = createPaymentRequest(orderId, paymentKey, amount);
         HttpHeaders headers = createRequestHeader();
         HttpEntity<Object> requestBody = new HttpEntity<>(paymentRequestBody, headers);
@@ -62,7 +61,7 @@ public class PaymentGatewayHandler {
         return "Basic "+ new String(encodedSecretKey, 0, encodedSecretKey.length);
     }
 
-    public PaymentInfo cancelPaymentRequest(Payment payment) throws JsonProcessingException {
+    public PaymentInfo cancelPaymentRequest(Payment payment) {
         String url = format("https://api.tosspayments.com/v1/payments/{0}/cancel", payment.getPgInfo().getPayKey());
         HttpEntity<PaymentCancelRequest> requestBody = new HttpEntity<>(new PaymentCancelRequest("결제취소사유"), createRequestHeader());
 

--- a/src/main/java/com/ray/pomin/payment/service/PaymentGatewayResponseParser.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentGatewayResponseParser.java
@@ -1,0 +1,55 @@
+package com.ray.pomin.payment.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ray.pomin.payment.controller.dto.PaymentInfo;
+import com.ray.pomin.payment.domain.PayMethod;
+import com.ray.pomin.payment.domain.PayType;
+import com.ray.pomin.payment.domain.PaymentStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+import static com.ray.pomin.payment.domain.PayMethod.EASYPAY;
+import static com.ray.pomin.payment.domain.PayMethod.findByTitle;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentGatewayResponseParser {
+
+    private final ObjectMapper objectMapper;
+
+    public PaymentInfo getPaymentInfoFrom(ResponseEntity<String> response) throws JsonProcessingException {
+        JsonNode jsonNode = objectMapper.readTree(response.getBody());
+        int amount = jsonNode.get("totalAmount").intValue();
+        PaymentStatus status = jsonNode.get("status").textValue().equals("DONE") ? PaymentStatus.COMPLETE : PaymentStatus.CANCELED;
+        String paymentKey = jsonNode.get("paymentKey").textValue();
+        PayMethod payMethod = findByTitle(jsonNode.get("method").textValue());
+        PayType payType = getPayType(jsonNode, payMethod);
+        LocalDateTime approvedAt = getApprovedAt(jsonNode);
+
+        return new PaymentInfo(amount, status, paymentKey, payMethod, payType, approvedAt);
+    }
+
+    private LocalDateTime getApprovedAt(JsonNode jsonNode) {
+        if (jsonNode.get("status").textValue().equals("CANCELED")) {
+            String canceledAt = jsonNode.get("cancels").get(0).get("canceledAt").textValue().split("\\+")[0];
+            return LocalDateTime.parse(canceledAt);
+        }
+        String approvedAt = jsonNode.get("approvedAt").textValue().split("\\+")[0];
+        return LocalDateTime.parse(approvedAt);
+    }
+
+    private PayType getPayType(JsonNode jsonNode, PayMethod payMethod) {
+        if (payMethod == EASYPAY) {
+            return PayType.findByTitle(jsonNode.get("easyPay").get("provider").textValue());
+        }
+        return PayType.findByCode(jsonNode.get("card").get("issuerCode").textValue());
+    }
+
+}

--- a/src/main/java/com/ray/pomin/payment/service/PaymentGatewayResponseParser.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentGatewayResponseParser.java
@@ -8,7 +8,6 @@ import com.ray.pomin.payment.domain.PayMethod;
 import com.ray.pomin.payment.domain.PayType;
 import com.ray.pomin.payment.domain.PaymentStatus;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
@@ -17,7 +16,6 @@ import java.time.LocalDateTime;
 import static com.ray.pomin.payment.domain.PayMethod.EASYPAY;
 import static com.ray.pomin.payment.domain.PayMethod.findByTitle;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentGatewayResponseParser {
@@ -26,30 +24,40 @@ public class PaymentGatewayResponseParser {
 
     public PaymentInfo getPaymentInfoFrom(ResponseEntity<String> response) throws JsonProcessingException {
         JsonNode jsonNode = objectMapper.readTree(response.getBody());
-        int amount = jsonNode.get("totalAmount").intValue();
-        PaymentStatus status = jsonNode.get("status").textValue().equals("DONE") ? PaymentStatus.COMPLETE : PaymentStatus.CANCELED;
-        String paymentKey = jsonNode.get("paymentKey").textValue();
-        PayMethod payMethod = findByTitle(jsonNode.get("method").textValue());
+        int amount = extractIntValue(jsonNode,"totalAmount");
+        PaymentStatus status = extractValue(jsonNode,"status").equals("DONE") ? PaymentStatus.COMPLETE : PaymentStatus.CANCELED;
+        String paymentKey = extractValue(jsonNode, "paymentKey");
+        PayMethod payMethod = findByTitle(extractValue(jsonNode,"method"));
         PayType payType = getPayType(jsonNode, payMethod);
-        LocalDateTime approvedAt = getApprovedAt(jsonNode);
+        LocalDateTime approvedAt = getTime(jsonNode);
 
         return new PaymentInfo(amount, status, paymentKey, payMethod, payType, approvedAt);
     }
 
-    private LocalDateTime getApprovedAt(JsonNode jsonNode) {
-        if (jsonNode.get("status").textValue().equals("CANCELED")) {
-            String canceledAt = jsonNode.get("cancels").get(0).get("canceledAt").textValue().split("\\+")[0];
-            return LocalDateTime.parse(canceledAt);
-        }
-        String approvedAt = jsonNode.get("approvedAt").textValue().split("\\+")[0];
-        return LocalDateTime.parse(approvedAt);
+    private int extractIntValue(JsonNode jsonNode, String valueName) {
+        return jsonNode.get(valueName).intValue();
     }
 
+    private String extractValue(JsonNode jsonNode, String valueName) {
+        return jsonNode.get(valueName).textValue();
+    }
+
+    private LocalDateTime extractTimeValue(JsonNode jsonNode, String valueName) {
+        String time = jsonNode.get(valueName).textValue().split("\\+")[0];
+        return LocalDateTime.parse(time);
+    }
     private PayType getPayType(JsonNode jsonNode, PayMethod payMethod) {
         if (payMethod == EASYPAY) {
-            return PayType.findByTitle(jsonNode.get("easyPay").get("provider").textValue());
+            return PayType.findByTitle(extractValue(jsonNode,"easyPay"));
         }
-        return PayType.findByCode(jsonNode.get("card").get("issuerCode").textValue());
+        return PayType.findByCode(extractValue(jsonNode.get("card"), "issuerCode"));
+    }
+
+    private LocalDateTime getTime(JsonNode jsonNode) {
+        if (jsonNode.get("status").textValue().equals("CANCELED")) {
+            return extractTimeValue(jsonNode.get("cancels").get(0), "canceledAt");
+        }
+        return extractTimeValue(jsonNode, "approvedAt");
     }
 
 }

--- a/src/main/java/com/ray/pomin/payment/service/PaymentService.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentService.java
@@ -5,13 +5,11 @@ import com.ray.pomin.payment.controller.dto.PaymentInfo;
 import com.ray.pomin.payment.domain.Payment;
 import com.ray.pomin.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
 
-@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor

--- a/src/main/java/com/ray/pomin/payment/service/PaymentService.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentService.java
@@ -1,121 +1,39 @@
 package com.ray.pomin.payment.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ray.pomin.payment.controller.dto.PaymentCancelRequest;
-import com.ray.pomin.payment.domain.PGInfo;
-import com.ray.pomin.payment.domain.PGType;
-import com.ray.pomin.payment.domain.PayInfo;
-import com.ray.pomin.payment.domain.PayMethod;
-import com.ray.pomin.payment.domain.PayType;
+import com.ray.pomin.payment.controller.dto.PaymentInfo;
 import com.ray.pomin.payment.domain.Payment;
 import com.ray.pomin.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
-import java.text.MessageFormat;
-import java.util.Map;
 import java.util.NoSuchElementException;
-
-import static com.ray.pomin.payment.domain.PayMethod.EASYPAY;
-import static com.ray.pomin.payment.domain.PayMethod.findByTitle;
-import static com.ray.pomin.payment.domain.PaymentStatus.COMPLETE;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Base64.getEncoder;
-import static org.springframework.http.HttpMethod.POST;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class PaymentService {
 
-  @Value("${toss.api.testSecretApiKey}")
-  private String secretKey;
-
-  private final ObjectMapper objectMapper;
-
   private final PaymentRepository paymentRepository;
 
-  @Transactional
-  public Long doFinalPaymentRequest(String orderId, String paymentKey, int amount) throws JsonProcessingException {
-    ResponseEntity<String> responseEntity = sendFinalPaymentRequest(orderId, paymentKey, amount);
+  private final PaymentGatewayHandler paymentGatewayHandler;
 
-    return paymentRepository.save(createPayment(responseEntity.getBody())).getId();
+  public Long create(String orderId, String paymentKey, int amount) throws JsonProcessingException {
+    PaymentInfo paymentInfo = paymentGatewayHandler.makePaymentRequest(orderId, paymentKey, amount);
+    Payment payment = paymentInfo.toEntity();
+
+    return paymentRepository.save(payment).getId();
   }
 
-  private ResponseEntity<String> sendFinalPaymentRequest(String orderId, String paymentKey, int amount) {
-    RestTemplate restTemplate = new RestTemplate();
-    Map<String, String> paymentRequestBody = createPaymentRequest(orderId, paymentKey, amount);
-    HttpHeaders headers = createRequestHeader();
-    HttpEntity<Object> requestBody = new HttpEntity<>(paymentRequestBody, headers);
-
-    String url = "https://api.tosspayments.com/v1/payments/confirm";
-
-    return restTemplate.postForEntity(url, requestBody, String.class);
+  public void cancel(Payment payment) throws JsonProcessingException {
+    PaymentInfo paymentInfo = paymentGatewayHandler.cancelPaymentRequest(payment);
+    paymentRepository.save(payment.cancel(paymentInfo));
   }
 
-  private Map<String, String> createPaymentRequest(String orderId, String paymentKey, int amount) {
-    return Map.of("paymentKey", paymentKey,
-                  "orderId", orderId,
-                  "amount", String.valueOf(amount));
-  }
-
-  private HttpHeaders createRequestHeader() {
-    HttpHeaders headers = new HttpHeaders();
-    headers.set("Authorization", getAuthorizations());
-    headers.setContentType(MediaType.APPLICATION_JSON);
-
-    return headers;
-  }
-
-  private Payment createPayment(String responseBody) throws JsonProcessingException {
-    JsonNode jsonNode = objectMapper.readTree(responseBody);
-    String paymentKey = jsonNode.get("paymentKey").textValue();
-    int amount = jsonNode.get("totalAmount").intValue();
-    PayMethod payMethod = findByTitle(jsonNode.get("method").textValue());
-    PayType payType = getPayType(jsonNode, payMethod);
-
-    return new Payment(amount, COMPLETE, new PGInfo(PGType.TOSS, paymentKey),
-            new PayInfo(payMethod, payType));
-  }
-
-  private static PayType getPayType(JsonNode jsonNode, PayMethod payMethod) {
-    if (payMethod == EASYPAY) {
-       return PayType.findByTitle(jsonNode.get("easyPay").get("provider").textValue());
-    }
-    return PayType.findByCode(jsonNode.get("card").get("issuerCode").textValue());
-  }
-
-  private String getAuthorizations() {
-    byte[] encodedSecretKey = getEncoder().encode((secretKey + ":").getBytes(UTF_8));
-
-    return "Basic "+ new String(encodedSecretKey, 0, encodedSecretKey.length);
-  }
-
-  @Transactional
-  public void cancel(Payment payment) {
-      sendPaymentCancelRequest(payment);
-      Payment canceledPayment = payment.cancel();
-      paymentRepository.save(canceledPayment);
-  }
-
-  private void sendPaymentCancelRequest(Payment payment) {
-    RestTemplate restTemplate = new RestTemplate();
-    String url = MessageFormat.format("https://api.tosspayments.com/v1/payments/{0}/cancel", payment.getPgInfo().getPayKey());
-    HttpEntity<PaymentCancelRequest> requestBody = new HttpEntity<>(new PaymentCancelRequest("결제취소사유"), createRequestHeader());
-
-    restTemplate.exchange(url, POST, requestBody, String.class);
-  }
-
+  @Transactional(readOnly = true)
   public Payment findOne(Long paymentId) {
     return paymentRepository.findById(paymentId)
             .orElseThrow(() -> new NoSuchElementException("존재하지 않는 결제건 입니다."));

--- a/src/main/java/com/ray/pomin/payment/service/PaymentService.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentService.java
@@ -1,6 +1,5 @@
 package com.ray.pomin.payment.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ray.pomin.payment.controller.dto.PaymentInfo;
 import com.ray.pomin.payment.domain.Payment;
 import com.ray.pomin.payment.repository.PaymentRepository;
@@ -19,16 +18,17 @@ public class PaymentService {
 
   private final PaymentGatewayHandler paymentGatewayHandler;
 
-  public Long create(String orderId, String paymentKey, int amount) throws JsonProcessingException {
+  public Long create(String orderId, String paymentKey, int amount) {
     PaymentInfo paymentInfo = paymentGatewayHandler.makePaymentRequest(orderId, paymentKey, amount);
     Payment payment = paymentInfo.toEntity();
 
     return paymentRepository.save(payment).getId();
   }
 
-  public void cancel(Payment payment) throws JsonProcessingException {
+  public void cancel(Payment payment) {
     PaymentInfo paymentInfo = paymentGatewayHandler.cancelPaymentRequest(payment);
-    paymentRepository.save(payment.cancel(paymentInfo));
+    Payment paymentCanceled = payment.cancel(paymentInfo.approvedAt());
+    paymentRepository.save(paymentCanceled);
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 PR 설명
- PaymentService 에서 PaymentGatewayHandler, PaymentGatewayResponseParser 분리
- Payment 클래스 BaseEntity 상속 제거 -> 정확한 결제일시를 기록하기 위해 ApprovedAt 추가 

##  📌 질문
- 아직 JsonProcessingException 를 어떤 방식으로 처리할지 결정하지 못했습니다. 조언주시면 감사하겠습니다!