### PR TITLE
[POM-74] feat: OAuth 사용자 정보 redis 저장 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ ext {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/ray/pomin/customer/controller/dto/SaveCustomerRequest.java
+++ b/src/main/java/com/ray/pomin/customer/controller/dto/SaveCustomerRequest.java
@@ -18,7 +18,7 @@ public record SaveCustomerRequest(
         return new Customer(
                 new Login(email, password, encoder), nickname,
                 new CustomerInfo(name, LocalDate.parse(birthDate), new PhoneNumber(phoneNumber)),
-                Provider.valueOf(provider)
+                Provider.valueOf(provider.toUpperCase())
         );
     }
 

--- a/src/main/java/com/ray/pomin/customer/service/CustomerService.java
+++ b/src/main/java/com/ray/pomin/customer/service/CustomerService.java
@@ -2,6 +2,8 @@ package com.ray.pomin.customer.service;
 
 import com.ray.pomin.customer.domain.Customer;
 import com.ray.pomin.customer.repository.CustomerRepository;
+import com.ray.pomin.global.auth.model.OAuthCustomerInfo;
+import com.ray.pomin.global.auth.model.OAuthCustomerInfoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +15,8 @@ public class CustomerService {
 
     private final CustomerRepository customerRepository;
 
+    private final OAuthCustomerInfoRepository oAuthUserInfoRepository;
+
     public Customer save(Customer customer) {
         customerRepository.findByLoginEmail(customer.getEmail())
                 .ifPresent(findCustomer -> {
@@ -20,6 +24,11 @@ public class CustomerService {
                 });
 
         return customerRepository.save(customer);
+    }
+
+    public OAuthCustomerInfo additionalCustomerInfo(Long oAuthId) {
+        return oAuthUserInfoRepository.findById(oAuthId)
+                .orElseThrow(() -> new IllegalArgumentException("소셜 로그인을 먼저 진행해야 합니다"));
     }
 
 }

--- a/src/main/java/com/ray/pomin/global/auth/OAuthSuccessHandler.java
+++ b/src/main/java/com/ray/pomin/global/auth/OAuthSuccessHandler.java
@@ -3,8 +3,11 @@ package com.ray.pomin.global.auth;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ray.pomin.customer.domain.Customer;
 import com.ray.pomin.customer.repository.CustomerRepository;
+import com.ray.pomin.global.auth.dto.CustomerRegistration;
 import com.ray.pomin.global.auth.model.Claims;
 import com.ray.pomin.global.auth.model.OAuthCustomer;
+import com.ray.pomin.global.auth.model.OAuthCustomerInfo;
+import com.ray.pomin.global.auth.model.OAuthCustomerInfoRepository;
 import com.ray.pomin.global.auth.model.Token;
 import com.ray.pomin.global.auth.token.JwtService;
 import jakarta.servlet.ServletException;
@@ -29,6 +32,8 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final CustomerRepository customerRepository;
 
+    private final OAuthCustomerInfoRepository oAuthUserInfoRepository;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         OAuthCustomer oAuthCustomer = (OAuthCustomer) authentication.getPrincipal();
@@ -47,9 +52,12 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
             return;
         }
 
-        response.setHeader("Location", "/api/v1/customers");
+        response.setHeader("Location", "/api/v1/customers/oauth");
 
-        response.getWriter().println(objectMapper.writeValueAsString(oAuthCustomer.getRegistration()));
+        CustomerRegistration registration = oAuthCustomer.getRegistration();
+        OAuthCustomerInfo save = oAuthUserInfoRepository.save(new OAuthCustomerInfo(registration.email(), registration.name(), registration.providerName()));
+
+        response.getWriter().println(objectMapper.writeValueAsString(save.getId()));
     }
 
 }

--- a/src/main/java/com/ray/pomin/global/auth/model/OAuthCustomerInfo.java
+++ b/src/main/java/com/ray/pomin/global/auth/model/OAuthCustomerInfo.java
@@ -1,0 +1,42 @@
+package com.ray.pomin.global.auth.model;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash("User")
+public class OAuthCustomerInfo {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String email;
+
+    private String name;
+
+    private String providerName;
+
+    public OAuthCustomerInfo(String email, String name, String providerName) {
+        this.email = email;
+        this.name = name;
+        this.providerName = providerName;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getProviderName() {
+        return providerName;
+    }
+
+}

--- a/src/main/java/com/ray/pomin/global/auth/model/OAuthCustomerInfoRepository.java
+++ b/src/main/java/com/ray/pomin/global/auth/model/OAuthCustomerInfoRepository.java
@@ -1,0 +1,7 @@
+package com.ray.pomin.global.auth.model;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface OAuthCustomerInfoRepository extends CrudRepository<OAuthCustomerInfo, Long> {
+
+}

--- a/src/main/java/com/ray/pomin/global/config/RedisConfiguration.java
+++ b/src/main/java/com/ray/pomin/global/config/RedisConfiguration.java
@@ -1,0 +1,19 @@
+package com.ray.pomin.global.config;
+
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfiguration {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(RedisProperties properties) {
+        return new LettuceConnectionFactory(properties.getHost(), properties.getPort());
+    }
+
+}


### PR DESCRIPTION
## 📌 설명
기존에 oAuth 사용자 정보를 다시 돌려주는 방식에서 서버 내부 redis에 저장 후 가입 시 조회하도록 변경하였습니다