### PR TITLE
[POM-69] feat: 도메인 테스트코드 추가 및 결제 취소 로직 수정

### DIFF
--- a/src/main/java/com/ray/pomin/payment/controller/PaymentController.java
+++ b/src/main/java/com/ray/pomin/payment/controller/PaymentController.java
@@ -10,7 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -33,14 +32,6 @@ public class PaymentController {
                                                   @RequestParam String message,
                                                   @RequestParam String orderId) {
     return new ResponseEntity<>(new PaymentFailResponse(message, orderId), HttpStatus.valueOf(code));
-  }
-
-  @PatchMapping("/payments/{paymentId}")
-  public ResponseEntity<Void> cancel(@PathVariable Long paymentId) {
-    Payment paymentToCancel = paymentService.findOne(paymentId);
-    paymentService.cancel(paymentToCancel);
-
-    return ResponseEntity.noContent().build();
   }
 
   @GetMapping("/payments/{paymentId}")

--- a/src/main/java/com/ray/pomin/payment/service/PaymentService.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentService.java
@@ -23,8 +23,10 @@ public class PaymentService {
     return paymentRepository.save(completedPayment).getId();
   }
 
-  public void cancel(Payment payment) {
-    Payment canceledPayment = paymentGatewayHandler.cancelPaymentRequest(payment);
+  public void cancel(Long paymentId) {
+    Payment paymentToCancel = paymentRepository.findById(paymentId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 결제건 입니다"));
+    Payment canceledPayment = paymentGatewayHandler.cancelPaymentRequest(paymentToCancel);
 
     paymentRepository.save(canceledPayment);
   }

--- a/src/test/java/com/ray/pomin/payment/domain/PaymentTest.java
+++ b/src/test/java/com/ray/pomin/payment/domain/PaymentTest.java
@@ -1,0 +1,98 @@
+package com.ray.pomin.payment.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDateTime;
+
+import static com.ray.pomin.payment.domain.PGType.TOSS;
+import static com.ray.pomin.payment.domain.PayMethod.CARD;
+import static com.ray.pomin.payment.domain.PayType.KAKAO_PAY;
+import static com.ray.pomin.payment.domain.PayType.KB;
+import static com.ray.pomin.payment.domain.PaymentStatus.CANCELED;
+import static com.ray.pomin.payment.domain.PaymentStatus.COMPLETE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PaymentTest {
+
+    @Test
+    @DisplayName("결제 생성에 성공한다")
+    void successCreatePayment() {
+        // given
+        Payment payment = Payment.builder()
+                            .amount(3000)
+                            .status(COMPLETE)
+                            .payInfo(new PayInfo(CARD, KB))
+                            .pgInfo(new PGInfo(TOSS, "payKey-randomValue3wd"))
+                            .approvedAt(LocalDateTime.now())
+                            .build();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -100})
+    @DisplayName("총액이 음수 또는 0인 결제 생성에 실패한다")
+    void failCreatePaymentWithInvalidAmount(int amount) {
+        //when, then
+        assertThatThrownBy(() -> Payment.builder()
+                .amount(amount)
+                .status(COMPLETE)
+                .payInfo(new PayInfo(CARD, KB))
+                .pgInfo(new PGInfo(TOSS, "payKey-randomValue3wd"))
+                .approvedAt(LocalDateTime.now())
+                .build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("결제 수단과 결제 타입이 서로 매칭되지 않으면 결제 생성에 실패한다")
+    public void failCreatePaymentWithInvalidPayUnit() {
+        //when, then
+        assertThatThrownBy(() -> Payment.builder()
+                .amount(100)
+                .status(COMPLETE)
+                .payInfo(new PayInfo(CARD, KAKAO_PAY))
+                .pgInfo(new PGInfo(TOSS, "payKey-randomValue3wd"))
+                .approvedAt(LocalDateTime.now())
+                .build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("승인시점이 미래인 결제는 생성할 수 없다")
+    void failCreatePaymentWithInvalidTime() {
+        // when, then
+        assertThatThrownBy(() -> Payment.builder()
+                .amount(1000)
+                .status(COMPLETE)
+                .payInfo(new PayInfo(CARD, KB))
+                .pgInfo(new PGInfo(TOSS, "payKey-randomValue3wd"))
+                .approvedAt(LocalDateTime.now().plusHours(3))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("결제를 취소할 수 있다")
+    void successCancelPayment() {
+        // given
+        Payment payment = Payment.builder()
+                .amount(1000)
+                .status(COMPLETE)
+                .payInfo(new PayInfo(CARD, KB))
+                .pgInfo(new PGInfo(TOSS, "payKey-randomValue3wd"))
+                .approvedAt(LocalDateTime.now().minusHours(3))
+                .build();
+
+        // when
+        LocalDateTime canceledAt = LocalDateTime.now();
+        Payment canceledPayment = payment.cancel(canceledAt);
+
+        // then
+        assertEquals(canceledPayment.getStatus(), CANCELED);
+        assertEquals(canceledPayment.getApprovedAt(), canceledAt);
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 도메인 테스트 코드 추가
- 결제 취소 엔드포인트 삭제 (주문 취소 후 하나의 트랜잭션 내에서 결제 취소가 이루어져야 맞다고 판단)
- 서비스 테스트 코드 추가 예정