### PR TITLE
[POM-69] fix: 결제 도메인에 사용자 ID 값 추가 및 결제 요청/취소 시 사용자 확인

### DIFF
--- a/src/main/java/com/ray/pomin/order/controller/OrderController.java
+++ b/src/main/java/com/ray/pomin/order/controller/OrderController.java
@@ -1,7 +1,7 @@
 package com.ray.pomin.order.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ray.pomin.global.auth.model.Claims;
+import com.ray.pomin.global.auth.model.JwtUser;
 import com.ray.pomin.order.Cart;
 import com.ray.pomin.order.Order;
 import com.ray.pomin.order.controller.dto.OrderResponse;
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
@@ -52,9 +51,10 @@ public class OrderController {
     @GetMapping("/orders/payOrder")
     public ResponseEntity<Void> create(@RequestParam String orderNumber,
                                        @RequestParam String paymentKey,
-                                       @RequestParam int amount) {
-        Long paymentId = paymentService.create(orderNumber, paymentKey, amount);
+                                       @RequestParam int amount,
+                                       @AuthenticationPrincipal JwtUser user) {
         Order order = orderService.getOrderByOrderNumber(orderNumber);
+        Long paymentId = paymentService.create(orderNumber, paymentKey, amount, order.getCustomerId());
         payOrder(order, paymentKey);
         return ResponseEntity.created(URI.create("/api/v1/payments" + paymentId)).build();
     }

--- a/src/main/java/com/ray/pomin/payment/controller/PaymentController.java
+++ b/src/main/java/com/ray/pomin/payment/controller/PaymentController.java
@@ -1,5 +1,6 @@
 package com.ray.pomin.payment.controller;
 
+import com.ray.pomin.global.auth.model.JwtUser;
 import com.ray.pomin.payment.controller.dto.PaymentFailResponse;
 import com.ray.pomin.payment.controller.dto.PaymentResponse;
 import com.ray.pomin.payment.domain.Payment;
@@ -7,6 +8,7 @@ import com.ray.pomin.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,27 +20,27 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequiredArgsConstructor
 public class PaymentController {
 
-  private final PaymentService paymentService;
+    private final PaymentService paymentService;
 
-  @GetMapping("/payment")
-  public String payPage(@RequestParam String orderId, Model model) {
-    // orderService 에서 orderId로 조회해서 model 에 담아서 전달
-    return "pay-test-page";
-  }
+    @GetMapping("/payment")
+    public String payPage(@RequestParam String orderId, Model model) {
+        // orderService 에서 orderId로 조회해서 model 에 담아서 전달
+        return "pay-test-page";
+    }
 
-  @ResponseBody
-  @GetMapping("/payment/fail")
-  public ResponseEntity<PaymentFailResponse> fail(@RequestParam String code,
-                                                  @RequestParam String message,
-                                                  @RequestParam String orderId) {
-    return new ResponseEntity<>(new PaymentFailResponse(message, orderId), HttpStatus.valueOf(code));
-  }
+    @ResponseBody
+    @GetMapping("/payment/fail")
+    public ResponseEntity<PaymentFailResponse> fail(@RequestParam String code,
+                                                    @RequestParam String message,
+                                                    @RequestParam String orderId) {
+        return new ResponseEntity<>(new PaymentFailResponse(message, orderId), HttpStatus.valueOf(code));
+    }
 
-  @GetMapping("/payments/{paymentId}")
-  public PaymentResponse find(@PathVariable Long paymentId) {
-    Payment payment = paymentService.findOne(paymentId);
+    @GetMapping("/payments/{paymentId}")
+    public PaymentResponse find(@PathVariable Long paymentId, @AuthenticationPrincipal JwtUser user) {
+        Payment payment = paymentService.findOneCheckingAuth(paymentId, user.userId());
 
-    return new PaymentResponse(payment);
-  }
+        return new PaymentResponse(payment);
+    }
 
 }

--- a/src/main/java/com/ray/pomin/payment/controller/dto/PaymentRequestInfo.java
+++ b/src/main/java/com/ray/pomin/payment/controller/dto/PaymentRequestInfo.java
@@ -1,0 +1,5 @@
+package com.ray.pomin.payment.controller.dto;
+
+public record PaymentRequestInfo(String orderId, String paymentKey, int amount, Long customerId) {
+
+}

--- a/src/main/java/com/ray/pomin/payment/domain/Payment.java
+++ b/src/main/java/com/ray/pomin/payment/domain/Payment.java
@@ -25,54 +25,58 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class Payment {
 
-  @Id
-  @GeneratedValue
-  @Column(name = "PAYMENT_ID")
-  private Long id;
+    @Id
+    @GeneratedValue
+    @Column(name = "PAYMENT_ID")
+    private Long id;
 
-  private int amount;
+    private int amount;
 
-  @Enumerated(STRING)
-  private PaymentStatus status;
+    @Enumerated(STRING)
+    private PaymentStatus status;
 
-  @Embedded
-  private PGInfo pgInfo;
+    @Embedded
+    private PGInfo pgInfo;
 
-  @Embedded
-  private PayInfo payInfo;
+    @Embedded
+    private PayInfo payInfo;
 
-  private LocalDateTime approvedAt;
+    private LocalDateTime approvedAt;
 
-  @Builder
-  private Payment(Long id, int amount, PaymentStatus status, PGInfo pgInfo, PayInfo payInfo, LocalDateTime approvedAt) {
-    validatePayment(amount, status, pgInfo, payInfo, approvedAt);
+    private Long customerId;
 
-    this.id = id;
-    this.amount = amount;
-    this.status = status;
-    this.pgInfo = pgInfo;
-    this.payInfo = payInfo;
-    this.approvedAt = approvedAt;
-  }
+    @Builder
+    private Payment(Long id, int amount, PaymentStatus status, PGInfo pgInfo, PayInfo payInfo, LocalDateTime approvedAt, Long customerId) {
+        validatePayment(amount, status, pgInfo, payInfo, approvedAt);
 
-  private void validatePayment(int amount, PaymentStatus status, PGInfo pgInfo, PayInfo payInfo, LocalDateTime approvedAt) {
-    validate(amount > 0, "결제금액은 0 보다 커야합니다");
-    validate(!isNull(status), "결제상태는 필수 값입니다");
-    validate(!isNull(pgInfo), "PG사 정보는 필수 값입니다");
-    validate(!isNull(payInfo), "결제 수단 정보는 필수 값입니다");
-    validate(!isNull(approvedAt), "결제 일시는 필수 값입니다");
-    validate(approvedAt.isBefore(LocalDateTime.now()), "결제일시가 유효하지 않습니다");
-  }
+        this.id = id;
+        this.amount = amount;
+        this.status = status;
+        this.pgInfo = pgInfo;
+        this.payInfo = payInfo;
+        this.approvedAt = approvedAt;
+        this.customerId = customerId;
+    }
 
-  public Payment cancel(LocalDateTime canceledAt) {
-    return Payment.builder()
-                    .id(id)
-                    .amount(amount)
-                    .status(CANCELED)
-                    .pgInfo(new PGInfo(pgInfo.getProvider(), pgInfo.getPayKey()))
-                    .payInfo(new PayInfo(payInfo.getMethod(), payInfo.getType()))
-                    .approvedAt(canceledAt)
-                    .build();
-  }
+    private void validatePayment(int amount, PaymentStatus status, PGInfo pgInfo, PayInfo payInfo, LocalDateTime approvedAt) {
+        validate(amount > 0, "결제금액은 0 보다 커야합니다");
+        validate(!isNull(status), "결제상태는 필수 값입니다");
+        validate(!isNull(pgInfo), "PG사 정보는 필수 값입니다");
+        validate(!isNull(payInfo), "결제 수단 정보는 필수 값입니다");
+        validate(!isNull(approvedAt), "결제 일시는 필수 값입니다");
+        validate(approvedAt.isBefore(LocalDateTime.now()), "결제일시가 유효하지 않습니다");
+    }
+
+    public Payment cancel(LocalDateTime canceledAt) {
+        return Payment.builder()
+                .id(id)
+                .amount(amount)
+                .status(CANCELED)
+                .pgInfo(new PGInfo(pgInfo.getProvider(), pgInfo.getPayKey()))
+                .payInfo(new PayInfo(payInfo.getMethod(), payInfo.getType()))
+                .approvedAt(canceledAt)
+                .customerId(customerId)
+                .build();
+    }
 
 }

--- a/src/main/java/com/ray/pomin/payment/service/PaymentGatewayHandler.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentGatewayHandler.java
@@ -1,6 +1,7 @@
 package com.ray.pomin.payment.service;
 
 import com.ray.pomin.payment.controller.dto.PaymentCancelRequest;
+import com.ray.pomin.payment.controller.dto.PaymentRequestInfo;
 import com.ray.pomin.payment.domain.Payment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,15 +30,15 @@ public class PaymentGatewayHandler {
 
     private final PaymentGatewayResponseParser parser;
 
-    Payment makePaymentRequest(String orderId, String paymentKey, int amount) {
-        Map<String, String> paymentRequestBody = createPaymentRequest(orderId, paymentKey, amount);
+    Payment makePaymentRequest(PaymentRequestInfo paymentRequestInfo) {
+        Map<String, String> paymentRequestBody = createPaymentRequest(paymentRequestInfo.orderId(), paymentRequestInfo.paymentKey(), paymentRequestInfo.amount());
         HttpHeaders headers = createRequestHeader();
         HttpEntity<Object> requestBody = new HttpEntity<>(paymentRequestBody, headers);
 
         String url = "https://api.tosspayments.com/v1/payments/confirm";
         ResponseEntity<String> response = restTemplate.exchange(url, POST, requestBody, String.class);
 
-        return parser.getPayment(response);
+        return parser.getPayment(response, paymentRequestInfo.customerId());
     }
 
     private Map<String, String> createPaymentRequest(String orderId, String paymentKey, int amount) {
@@ -57,14 +58,14 @@ public class PaymentGatewayHandler {
     private String getAuthorizations() {
         byte[] encodedSecretKey = getEncoder().encode((secretKey + ":").getBytes(UTF_8));
 
-        return "Basic "+ new String(encodedSecretKey, 0, encodedSecretKey.length);
+        return "Basic " + new String(encodedSecretKey, 0, encodedSecretKey.length);
     }
 
     public Payment cancelPaymentRequest(Payment payment) {
         String url = format("https://api.tosspayments.com/v1/payments/{0}/cancel", payment.getPgInfo().getPayKey());
         HttpEntity<PaymentCancelRequest> requestBody = new HttpEntity<>(new PaymentCancelRequest("결제취소사유"), createRequestHeader());
         ResponseEntity<String> response = restTemplate.exchange(url, POST, requestBody, String.class);
-        Payment canceledPayment = parser.getPayment(response);
+        Payment canceledPayment = parser.getPayment(response, payment.getCustomerId());
 
         return payment.cancel(canceledPayment.getApprovedAt());
     }

--- a/src/main/java/com/ray/pomin/payment/service/PaymentService.java
+++ b/src/main/java/com/ray/pomin/payment/service/PaymentService.java
@@ -1,5 +1,6 @@
 package com.ray.pomin.payment.service;
 
+import com.ray.pomin.payment.controller.dto.PaymentRequestInfo;
 import com.ray.pomin.payment.domain.Payment;
 import com.ray.pomin.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,34 +14,41 @@ import java.util.NoSuchElementException;
 @RequiredArgsConstructor
 public class PaymentService {
 
-  private final PaymentRepository paymentRepository;
+    private final PaymentRepository paymentRepository;
 
-  private final PaymentGatewayHandler paymentGatewayHandler;
+    private final PaymentGatewayHandler paymentGatewayHandler;
 
-  public Long create(String orderId, String paymentKey, int amount) {
-    Payment completedPayment = paymentGatewayHandler.makePaymentRequest(orderId, paymentKey, amount);
+    public Long create(String orderId, String paymentKey, int amount, Long customerId) {
+        Payment completedPayment = paymentGatewayHandler.makePaymentRequest(new PaymentRequestInfo(orderId, paymentKey, amount, customerId));
 
-    return paymentRepository.save(completedPayment).getId();
-  }
+        return paymentRepository.save(completedPayment).getId();
+    }
 
-  public void cancel(Long paymentId) {
-    Payment paymentToCancel = paymentRepository.findById(paymentId)
-            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 결제건 입니다"));
-    Payment canceledPayment = paymentGatewayHandler.cancelPaymentRequest(paymentToCancel);
+    public void cancel(Long paymentId) {
+        Payment paymentToCancel = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 결제건 입니다"));
+        Payment canceledPayment = paymentGatewayHandler.cancelPaymentRequest(paymentToCancel);
 
-    paymentRepository.save(canceledPayment);
-  }
+        paymentRepository.save(canceledPayment);
+    }
 
-  @Transactional(readOnly = true)
-  public Payment findOne(Long paymentId) {
-    return paymentRepository.findById(paymentId)
-            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 결제건 입니다."));
-  }
+    @Transactional(readOnly = true)
+    public Payment findOne(Long paymentId) {
+        return paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 결제건 입니다."));
+    }
 
-  @Transactional(readOnly = true)
-  public Payment findByPgInfoPayKey(String payKey) {
-    return paymentRepository.findByPgInfoPayKey(payKey)
-            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 결제건 입니다."));
-  }
+    @Transactional(readOnly = true)
+    public Payment findOneCheckingAuth(Long paymentId, Long customerId) {
+        return paymentRepository.findById(paymentId)
+                .filter(payment -> payment.getCustomerId().equals(customerId))
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 결제건 입니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public Payment findByPgInfoPayKey(String payKey) {
+        return paymentRepository.findByPgInfoPayKey(payKey)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 결제건 입니다."));
+    }
 
 }


### PR DESCRIPTION
## 📌 PR 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 결제 생성/조회/취소 시 현재 요청을 보낸 사용자 정보가 필요
    - 문제 : 사용자 정보를 얻으려면 orderService에 의존하게 됨 (paymentId로 order 찾아서 customerId 가져옴)
    - 해결방향 : id 값을 연관관계 설정없이 payment에 저장